### PR TITLE
fix: confirmation prompt, tier stat inflation, and rejected submission query

### DIFF
--- a/src/core/database/TaskRepo.ts
+++ b/src/core/database/TaskRepo.ts
@@ -3,7 +3,7 @@ import { GuildScopedRepository } from "./CoreRepo.js";
 import { db } from "./firestore.js";
 import type { Task } from "../../models/Task.js";
 import type { TaskPoll } from "../../models/TaskPoll.js";
-import type { TaskSubmission } from "../../models/TaskSubmission.js";
+import { SubmissionStatus, type TaskSubmission } from "../../models/TaskSubmission.js";
 import type { TaskEvent } from "../../models/TaskEvent.js";
 import type { TaskFeedback } from "../../models/TaskFeedback.js";
 import type { ITaskRepository } from "./interfaces/ITaskRepo.js";
@@ -217,6 +217,7 @@ export class TaskRepository extends GuildScopedRepository<Task> implements ITask
         const snapshot = await this.submissionsCollection
             .where('userId', '==', userId)
             .where('taskEventId', '==', taskEventId)
+            .where('status', 'in', [SubmissionStatus.Bronze, SubmissionStatus.Silver, SubmissionStatus.Gold])
             .orderBy('reviewedAt', 'desc')
             .limit(1)
             .get();

--- a/src/core/database/UserRepo.ts
+++ b/src/core/database/UserRepo.ts
@@ -86,6 +86,28 @@ export class UserRepository extends GuildScopedRepository<UserStats> implements 
         });
     }
 
+    async updateTierStat(
+        userId: string,
+        fromField: keyof UserStats,
+        toField: keyof UserStats
+    ): Promise<void> {
+        const docRef = this.collection.doc(userId);
+        const doc = await docRef.get();
+
+        if (!doc.exists) {
+            const newStats = this.createDefaultUserStats(userId);
+            (newStats as any)[toField] = 1;
+            await docRef.set(newStats);
+            return;
+        }
+
+        await docRef.update({
+            [fromField]: FieldValue.increment(-1),
+            [toField]: FieldValue.increment(1),
+            lastActiveAt: new Date(),
+        });
+    }
+
     async updateLastActive(userId: string): Promise<void> {
         await this.collection.doc(userId).update({
             lastActiveAt: new Date(),

--- a/src/core/database/interfaces/IUserRepo.ts
+++ b/src/core/database/interfaces/IUserRepo.ts
@@ -5,6 +5,7 @@ export interface IUserRepository {
     getUserById(userId: string): Promise<UserStats | null>;
     createUser(user: UserStats): Promise<void>;
     incrementStat(userId: string, field: keyof UserStats, amount?: number): Promise<void>;
+    updateTierStat(userId: string, fromField: keyof UserStats, toField: keyof UserStats): Promise<void>;
     updateLastActive(userId: string): Promise<void>;
     updateUser(userId: string, data: Partial<UserStats>): Promise<void>;
     deleteUser(userId: string): Promise<void>;

--- a/src/modules/movies/__tests__/MovieScheduler.test.ts
+++ b/src/modules/movies/__tests__/MovieScheduler.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { DateTime } from "luxon";
+import type { Reminder } from "../../../models/Reminder.js";
 
 const createMovieNightEmbed = vi.fn(() => ({ id: "embed" }));
 vi.mock("../MovieEmbeds", () => ({
@@ -12,7 +13,7 @@ vi.mock("../MoviePollScheduler", () => ({
 }));
 
 const scheduleMovieReminders = vi.fn().mockResolvedValue(undefined);
-const getPendingReminders = vi.fn(() => []);
+const getPendingReminders = vi.fn((): Reminder[] => []);
 vi.mock("../MovieReminders", () => ({
     scheduleMovieReminders,
     getPendingReminders,

--- a/src/modules/tasks/TaskInteractions.ts
+++ b/src/modules/tasks/TaskInteractions.ts
@@ -6,8 +6,15 @@ import { handleUpdateTaskModal } from './HandleUpdateTaskModal.js';
 import { getTierPoints, incrementLifetimePoints, incrementPeriodicPoints } from './TaskLeaderboards.js';
 import { applyTaskMilestoneRoles } from './TaskMilestones.js';
 import { isMentionSuppressed, withSuppressedMentions } from '../../utils/MentionUtils.js';
+import type { UserStats } from '../../models/UserStats.js';
 
 const MAX_SCREENSHOTS = 10;
+
+const TIER_STAT_MAP: Record<string, keyof UserStats> = {
+    bronze: "tasksCompletedBronze",
+    silver: "tasksCompletedSilver",
+    gold: "tasksCompletedGold",
+};
 
 // STEP 1: "Submit Screenshot" button clicked on task embed
 export async function handleSubmitButton(interaction: ButtonInteraction, services: ServiceContainer) {
@@ -224,7 +231,11 @@ export async function handleAdminButton(interaction: ButtonInteraction, services
             return;
         }
 
-        await interaction.deferReply({ flags: 1 << 6 });
+        await interaction.deferUpdate();
+        await interaction.editReply({
+            content: `⏳ Processing approval...`,
+            components: [],
+        });
 
         const reviewerId = interaction.user.id;
 
@@ -238,27 +249,24 @@ export async function handleAdminButton(interaction: ButtonInteraction, services
             );
 
             if (!result) {
-                await interaction.editReply({ content: "⚠️ Could not update submission. It may already be at this or a higher tier." });
+                await interaction.editReply({ content: "⚠️ This submission has already been processed or the user already holds this tier." });
                 return;
             }
 
             const userRepo = services.repos.userRepo;
             if (userRepo) {
                 const { userId } = result;
+                const prevStat = result.previousStatus ? TIER_STAT_MAP[result.previousStatus] : undefined;
+                const newStat = TIER_STAT_MAP[tier];
+
                 try {
-                    switch (tier) {
-                        case 'bronze':
-                            await userRepo.incrementStat(userId, "tasksCompletedBronze", 1);
-                            break;
-                        case 'silver':
-                            await userRepo.incrementStat(userId, "tasksCompletedSilver", 1);
-                            break;
-                        case 'gold':
-                            await userRepo.incrementStat(userId, "tasksCompletedGold", 1);
-                            break;
+                    if (prevStat && newStat) {
+                        await userRepo.updateTierStat(userId, prevStat, newStat);
+                    } else if (newStat) {
+                        await userRepo.incrementStat(userId, newStat, 1);
                     }
                 } catch (err) {
-                    console.warn(`[Stats] Failed to increment ${tier} completion for ${result.userId}:`, err);
+                    console.warn(`[Stats] Failed to update tier stats for ${userId}:`, err);
                 }
             } else {
                 console.warn("[Stats] UserRepo unavailable; skipping task completion increment.");
@@ -286,7 +294,8 @@ export async function handleAdminButton(interaction: ButtonInteraction, services
             }
 
             await interaction.editReply({
-                content: `✅ Submission approved for **${formattedTier} tier** (${result.prizeRolls ?? 0} roll${(result.prizeRolls ?? 0) > 1 ? 's' : ''}) and archived.`
+                content: `✅ Submission approved for **${formattedTier} tier** (${result.prizeRolls ?? 0} roll${(result.prizeRolls ?? 0) > 1 ? 's' : ''}) and archived.`,
+                components: []
             });
         } catch (err) {
             console.error('[TaskInteractions] Tier approval failed:', err);

--- a/src/modules/tasks/TaskService.ts
+++ b/src/modules/tasks/TaskService.ts
@@ -159,7 +159,7 @@ export class TaskService {
         tier: 'bronze' | 'silver' | 'gold',
         reviewedBy: string,
         services: ServiceContainer
-    ): Promise<(TaskSubmission & { streakLine?: string; previousTierPoints?: number }) | null> {
+    ): Promise<(TaskSubmission & { streakLine?: string; previousTierPoints: number; previousStatus?: SubmissionStatus }) | null> {
         const TIER_MAP = {
             bronze: { status: SubmissionStatus.Bronze },
             silver: { status: SubmissionStatus.Silver },
@@ -175,7 +175,8 @@ export class TaskService {
         // Retrieve any previous submission by the same user for this task
         const existing = await this.repo.getSubmissionByUserAndTask(submission.userId, submission.taskEventId);
 
-        const previousTierPoints = getStatusPoints(existing?.status);
+        const previousStatus = existing?.status;
+        const previousTierPoints = getStatusPoints(previousStatus);
         const nextTierPoints = getStatusPoints(tierInfo.status);
         if (previousTierPoints >= nextTierPoints) {
             // Already equal or higher tier
@@ -260,10 +261,13 @@ export class TaskService {
             }
         }
 
-        if (streakLine) {
-            return { ...submission, streakLine, previousTierPoints };
-        }
-        return { ...submission, previousTierPoints };
+        const result = {
+            ...submission,
+            previousTierPoints,
+            ...(streakLine && { streakLine }),
+            ...(previousStatus && { previousStatus }),
+        };
+        return result;
     }
 
     async getPendingSubmission(

--- a/src/modules/tasks/__tests__/TaskStreaks.test.ts
+++ b/src/modules/tasks/__tests__/TaskStreaks.test.ts
@@ -135,7 +135,6 @@ describe("Task streaks", () => {
         const createdLate = new Date(end.getTime() + 2 * 60 * 60 * 1000);
 
         const repo = buildRepo({
-            latestEventId: undefined,
             events: { "event-1": event },
             submissions: [
                 {

--- a/src/modules/tasks/__tests__/TaskSubmissionFlow.test.ts
+++ b/src/modules/tasks/__tests__/TaskSubmissionFlow.test.ts
@@ -119,7 +119,7 @@ describe('Task submission lifecycle', () => {
                 customId: `review-confirm|approve|bronze|${submission.id}`,
                 user: { id: 'admin-1' },
                 client,
-                deferReply: vi.fn().mockResolvedValue(undefined),
+                deferUpdate: vi.fn().mockResolvedValue(undefined),
                 editReply: vi.fn().mockResolvedValue(undefined),
                 channel: adminChannel,
             };
@@ -171,7 +171,7 @@ describe('Task submission lifecycle', () => {
                 customId: `review-confirm|approve|bronze|${submission.id}`,
                 user: { id: 'admin-1' },
                 client,
-                deferReply: vi.fn().mockResolvedValue(undefined),
+                deferUpdate: vi.fn().mockResolvedValue(undefined),
                 editReply: vi.fn().mockResolvedValue(undefined),
                 channel: adminChannel,
             };
@@ -214,7 +214,7 @@ describe('Task submission lifecycle', () => {
                 customId: `review-confirm|approve|bronze|${submission.id}`,
                 user: { id: 'admin-1' },
                 client,
-                deferReply: vi.fn().mockResolvedValue(undefined),
+                deferUpdate: vi.fn().mockResolvedValue(undefined),
                 editReply: vi.fn().mockResolvedValue(undefined),
                 update: vi.fn().mockResolvedValue(undefined),
                 channel: adminChannel,
@@ -228,7 +228,7 @@ describe('Task submission lifecycle', () => {
                 customId: `review-confirm|approve|bronze|${submission.id}`,
                 user: { id: 'admin-2' },
                 client,
-                deferReply: vi.fn().mockResolvedValue(undefined),
+                deferUpdate: vi.fn().mockResolvedValue(undefined),
                 editReply: vi.fn().mockResolvedValue(undefined),
                 update: vi.fn().mockResolvedValue(undefined),
                 channel: adminChannel,
@@ -278,7 +278,7 @@ describe('Task submission lifecycle', () => {
                 customId: `review-confirm|approve|silver|${submission.id}`,
                 user: { id: 'admin-1' },
                 client,
-                deferReply: vi.fn().mockResolvedValue(undefined),
+                deferUpdate: vi.fn().mockResolvedValue(undefined),
                 editReply: vi.fn().mockResolvedValue(undefined),
                 update: vi.fn().mockResolvedValue(undefined),
                 channel: adminChannel,
@@ -287,7 +287,7 @@ describe('Task submission lifecycle', () => {
             await handleAdminButton(admin1Confirm, services);
 
             // Should allow upgrade since Silver (tier 2) > Bronze (tier 1)
-            expect(admin1Confirm.deferReply).toHaveBeenCalled();
+            expect(admin1Confirm.deferUpdate).toHaveBeenCalled();
             expect(repo.updateSubmissionStatus).toHaveBeenCalled();
         });
 
@@ -313,7 +313,7 @@ describe('Task submission lifecycle', () => {
                 customId: `review-confirm|approve|bronze|${submission.id}`,
                 user: { id: 'admin-1' },
                 client,
-                deferReply: vi.fn().mockResolvedValue(undefined),
+                deferUpdate: vi.fn().mockResolvedValue(undefined),
                 editReply: vi.fn().mockResolvedValue(undefined),
                 update: vi.fn().mockResolvedValue(undefined),
                 channel: adminChannel,
@@ -330,8 +330,384 @@ describe('Task submission lifecycle', () => {
             );
 
             // Should not defer or update status
-            expect(admin1Confirm.deferReply).not.toHaveBeenCalled();
+            expect(admin1Confirm.deferUpdate).not.toHaveBeenCalled();
             expect(repo.updateSubmissionStatus).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('Tier upgrade stat handling', () => {
+        it('increments new tier stat on first-time approval', async () => {
+            const { service, repo, services } = createTaskServiceHarness();
+            const { client, adminChannel } = createAdminClientMock();
+
+            const userRepo = {
+                incrementStat: vi.fn().mockResolvedValue(undefined),
+                updateTierStat: vi.fn().mockResolvedValue(undefined),
+                getUserById: vi.fn().mockResolvedValue(null),
+                updateUser: vi.fn().mockResolvedValue(undefined),
+            };
+            (services.repos as any).userRepo = userRepo;
+
+            const submission = await service.createSubmission('user-1', 'event-1');
+            const stored = { ...submission, screenshotUrls: ['https://cdn/img.png'] };
+            repo.getSubmissionById.mockResolvedValue(stored);
+
+            await service.completeSubmission(client as any, submission.id, ['https://cdn/img.png'], services);
+
+            const confirmInteraction: any = {
+                customId: `review-confirm|approve|bronze|${submission.id}`,
+                user: { id: 'admin-1' },
+                client,
+                deferUpdate: vi.fn().mockResolvedValue(undefined),
+                editReply: vi.fn().mockResolvedValue(undefined),
+                channel: adminChannel,
+            };
+
+            await handleAdminButton(confirmInteraction, services);
+
+            expect(userRepo.incrementStat).toHaveBeenCalledWith('user-1', 'tasksCompletedBronze', 1);
+            expect(userRepo.updateTierStat).not.toHaveBeenCalled();
+        });
+
+        it('increments silver stat on first-time silver approval', async () => {
+            const { service, repo, services } = createTaskServiceHarness();
+            const { client, adminChannel } = createAdminClientMock();
+
+            const userRepo = {
+                incrementStat: vi.fn().mockResolvedValue(undefined),
+                updateTierStat: vi.fn().mockResolvedValue(undefined),
+                getUserById: vi.fn().mockResolvedValue(null),
+                updateUser: vi.fn().mockResolvedValue(undefined),
+            };
+            (services.repos as any).userRepo = userRepo;
+
+            const submission = await service.createSubmission('user-1', 'event-1');
+            const stored = { ...submission, screenshotUrls: ['https://cdn/img.png'] };
+            repo.getSubmissionById.mockResolvedValue(stored);
+
+            await service.completeSubmission(client as any, submission.id, ['https://cdn/img.png'], services);
+
+            const confirmInteraction: any = {
+                customId: `review-confirm|approve|silver|${submission.id}`,
+                user: { id: 'admin-1' },
+                client,
+                deferUpdate: vi.fn().mockResolvedValue(undefined),
+                editReply: vi.fn().mockResolvedValue(undefined),
+                channel: adminChannel,
+            };
+
+            await handleAdminButton(confirmInteraction, services);
+
+            expect(userRepo.incrementStat).toHaveBeenCalledWith('user-1', 'tasksCompletedSilver', 1);
+            expect(userRepo.updateTierStat).not.toHaveBeenCalled();
+        });
+
+        it('increments gold stat on first-time gold approval', async () => {
+            const { service, repo, services } = createTaskServiceHarness();
+            const { client, adminChannel } = createAdminClientMock();
+
+            const userRepo = {
+                incrementStat: vi.fn().mockResolvedValue(undefined),
+                updateTierStat: vi.fn().mockResolvedValue(undefined),
+                getUserById: vi.fn().mockResolvedValue(null),
+                updateUser: vi.fn().mockResolvedValue(undefined),
+            };
+            (services.repos as any).userRepo = userRepo;
+
+            const submission = await service.createSubmission('user-1', 'event-1');
+            const stored = { ...submission, screenshotUrls: ['https://cdn/img.png'] };
+            repo.getSubmissionById.mockResolvedValue(stored);
+
+            await service.completeSubmission(client as any, submission.id, ['https://cdn/img.png'], services);
+
+            const confirmInteraction: any = {
+                customId: `review-confirm|approve|gold|${submission.id}`,
+                user: { id: 'admin-1' },
+                client,
+                deferUpdate: vi.fn().mockResolvedValue(undefined),
+                editReply: vi.fn().mockResolvedValue(undefined),
+                channel: adminChannel,
+            };
+
+            await handleAdminButton(confirmInteraction, services);
+
+            expect(userRepo.incrementStat).toHaveBeenCalledWith('user-1', 'tasksCompletedGold', 1);
+            expect(userRepo.updateTierStat).not.toHaveBeenCalled();
+        });
+
+        it('calls updateTierStat to atomically decrement previous and increment new tier on upgrade', async () => {
+            const { service, repo, services } = createTaskServiceHarness();
+            const { client, adminChannel } = createAdminClientMock();
+
+            const userRepo = {
+                incrementStat: vi.fn().mockResolvedValue(undefined),
+                updateTierStat: vi.fn().mockResolvedValue(undefined),
+                getUserById: vi.fn().mockResolvedValue(null),
+                updateUser: vi.fn().mockResolvedValue(undefined),
+            };
+            (services.repos as any).userRepo = userRepo;
+
+            const submission = await service.createSubmission('user-1', 'event-1');
+            const stored = { ...submission, screenshotUrls: ['https://cdn/img.png'] };
+            repo.getSubmissionById.mockResolvedValue(stored);
+
+            await service.completeSubmission(client as any, submission.id, ['https://cdn/img.png'], services);
+
+            // Simulate existing bronze submission for this user+task
+            repo.getSubmissionByUserAndTask.mockResolvedValueOnce({
+                ...submission,
+                status: SubmissionStatus.Bronze,
+                screenshotUrls: ['https://cdn/img.png'],
+            });
+
+            const confirmInteraction: any = {
+                customId: `review-confirm|approve|silver|${submission.id}`,
+                user: { id: 'admin-1' },
+                client,
+                deferUpdate: vi.fn().mockResolvedValue(undefined),
+                editReply: vi.fn().mockResolvedValue(undefined),
+                channel: adminChannel,
+            };
+
+            await handleAdminButton(confirmInteraction, services);
+
+            expect(userRepo.updateTierStat).toHaveBeenCalledWith('user-1', 'tasksCompletedBronze', 'tasksCompletedSilver');
+            expect(userRepo.incrementStat).not.toHaveBeenCalled();
+        });
+
+        it('does not decrement or increment stats when approval is rejected (same or higher tier)', async () => {
+            const { service, repo, services } = createTaskServiceHarness();
+            const { client, adminChannel } = createAdminClientMock();
+
+            const userRepo = {
+                incrementStat: vi.fn().mockResolvedValue(undefined),
+                updateTierStat: vi.fn().mockResolvedValue(undefined),
+                getUserById: vi.fn().mockResolvedValue(null),
+                updateUser: vi.fn().mockResolvedValue(undefined),
+            };
+            (services.repos as any).userRepo = userRepo;
+
+            const submission = await service.createSubmission('user-1', 'event-1');
+            const stored = { ...submission, screenshotUrls: ['https://cdn/img.png'] };
+            repo.getSubmissionById.mockResolvedValue(stored);
+
+            await service.completeSubmission(client as any, submission.id, ['https://cdn/img.png'], services);
+
+            // Submission already at gold
+            repo.getSubmissionById.mockResolvedValueOnce({
+                ...submission,
+                status: SubmissionStatus.Gold,
+                screenshotUrls: ['https://cdn/img.png'],
+            });
+
+            const confirmInteraction: any = {
+                customId: `review-confirm|approve|bronze|${submission.id}`,
+                user: { id: 'admin-1' },
+                client,
+                deferUpdate: vi.fn().mockResolvedValue(undefined),
+                editReply: vi.fn().mockResolvedValue(undefined),
+                update: vi.fn().mockResolvedValue(undefined),
+                channel: adminChannel,
+            };
+
+            await handleAdminButton(confirmInteraction, services);
+
+            expect(userRepo.incrementStat).not.toHaveBeenCalled();
+            expect(userRepo.updateTierStat).not.toHaveBeenCalled();
+        });
+
+        it('uses updateTierStat for bronze to gold upgrade (skipping silver)', async () => {
+            const { service, repo, services } = createTaskServiceHarness();
+            const { client, adminChannel } = createAdminClientMock();
+
+            const userRepo = {
+                incrementStat: vi.fn().mockResolvedValue(undefined),
+                updateTierStat: vi.fn().mockResolvedValue(undefined),
+                getUserById: vi.fn().mockResolvedValue(null),
+                updateUser: vi.fn().mockResolvedValue(undefined),
+            };
+            (services.repos as any).userRepo = userRepo;
+
+            const submission = await service.createSubmission('user-1', 'event-1');
+            const stored = { ...submission, screenshotUrls: ['https://cdn/img.png'] };
+            repo.getSubmissionById.mockResolvedValue(stored);
+
+            await service.completeSubmission(client as any, submission.id, ['https://cdn/img.png'], services);
+
+            // Simulate existing bronze submission
+            repo.getSubmissionByUserAndTask.mockResolvedValueOnce({
+                ...submission,
+                status: SubmissionStatus.Bronze,
+                screenshotUrls: ['https://cdn/img.png'],
+            });
+
+            const confirmInteraction: any = {
+                customId: `review-confirm|approve|gold|${submission.id}`,
+                user: { id: 'admin-1' },
+                client,
+                deferUpdate: vi.fn().mockResolvedValue(undefined),
+                editReply: vi.fn().mockResolvedValue(undefined),
+                channel: adminChannel,
+            };
+
+            await handleAdminButton(confirmInteraction, services);
+
+            expect(userRepo.updateTierStat).toHaveBeenCalledWith('user-1', 'tasksCompletedBronze', 'tasksCompletedGold');
+            expect(userRepo.incrementStat).not.toHaveBeenCalled();
+        });
+
+        it('uses updateTierStat for silver to gold upgrade', async () => {
+            const { service, repo, services } = createTaskServiceHarness();
+            const { client, adminChannel } = createAdminClientMock();
+
+            const userRepo = {
+                incrementStat: vi.fn().mockResolvedValue(undefined),
+                updateTierStat: vi.fn().mockResolvedValue(undefined),
+                getUserById: vi.fn().mockResolvedValue(null),
+                updateUser: vi.fn().mockResolvedValue(undefined),
+            };
+            (services.repos as any).userRepo = userRepo;
+
+            const submission = await service.createSubmission('user-1', 'event-1');
+            const stored = { ...submission, screenshotUrls: ['https://cdn/img.png'] };
+            repo.getSubmissionById.mockResolvedValue(stored);
+
+            await service.completeSubmission(client as any, submission.id, ['https://cdn/img.png'], services);
+
+            repo.getSubmissionByUserAndTask.mockResolvedValueOnce({
+                ...submission,
+                status: SubmissionStatus.Silver,
+                screenshotUrls: ['https://cdn/img.png'],
+            });
+
+            const confirmInteraction: any = {
+                customId: `review-confirm|approve|gold|${submission.id}`,
+                user: { id: 'admin-1' },
+                client,
+                deferUpdate: vi.fn().mockResolvedValue(undefined),
+                editReply: vi.fn().mockResolvedValue(undefined),
+                channel: adminChannel,
+            };
+
+            await handleAdminButton(confirmInteraction, services);
+
+            expect(userRepo.updateTierStat).toHaveBeenCalledWith('user-1', 'tasksCompletedSilver', 'tasksCompletedGold');
+            expect(userRepo.incrementStat).not.toHaveBeenCalled();
+        });
+
+        it('finds bronze submission (not rejected) when user has bronze then rejection then silver upgrade', async () => {
+            const { service, repo, services } = createTaskServiceHarness();
+            const { client, adminChannel } = createAdminClientMock();
+
+            const userRepo = {
+                incrementStat: vi.fn().mockResolvedValue(undefined),
+                updateTierStat: vi.fn().mockResolvedValue(undefined),
+                getUserById: vi.fn().mockResolvedValue(null),
+                updateUser: vi.fn().mockResolvedValue(undefined),
+            };
+            (services.repos as any).userRepo = userRepo;
+
+            const submission = await service.createSubmission('user-1', 'event-1');
+            const stored = { ...submission, screenshotUrls: ['https://cdn/img.png'] };
+            repo.getSubmissionById.mockResolvedValue(stored);
+
+            await service.completeSubmission(client as any, submission.id, ['https://cdn/img.png'], services);
+
+            // getSubmissionByUserAndTask filters to tier statuses only,
+            // so a rejected submission with a later reviewedAt is excluded
+            // and the bronze submission is returned instead
+            repo.getSubmissionByUserAndTask.mockResolvedValueOnce({
+                ...submission,
+                status: SubmissionStatus.Bronze,
+                screenshotUrls: ['https://cdn/img.png'],
+            });
+
+            const confirmInteraction: any = {
+                customId: `review-confirm|approve|silver|${submission.id}`,
+                user: { id: 'admin-1' },
+                client,
+                deferUpdate: vi.fn().mockResolvedValue(undefined),
+                editReply: vi.fn().mockResolvedValue(undefined),
+                channel: adminChannel,
+            };
+
+            await handleAdminButton(confirmInteraction, services);
+
+            // Must decrement bronze and increment silver atomically
+            expect(userRepo.updateTierStat).toHaveBeenCalledWith('user-1', 'tasksCompletedBronze', 'tasksCompletedSilver');
+            expect(userRepo.incrementStat).not.toHaveBeenCalled();
+        });
+
+        it('treats no prior tier submission as first-time approval even if rejected submissions exist', async () => {
+            const { service, repo, services } = createTaskServiceHarness();
+            const { client, adminChannel } = createAdminClientMock();
+
+            const userRepo = {
+                incrementStat: vi.fn().mockResolvedValue(undefined),
+                updateTierStat: vi.fn().mockResolvedValue(undefined),
+                getUserById: vi.fn().mockResolvedValue(null),
+                updateUser: vi.fn().mockResolvedValue(undefined),
+            };
+            (services.repos as any).userRepo = userRepo;
+
+            const submission = await service.createSubmission('user-1', 'event-1');
+            const stored = { ...submission, screenshotUrls: ['https://cdn/img.png'] };
+            repo.getSubmissionById.mockResolvedValue(stored);
+
+            await service.completeSubmission(client as any, submission.id, ['https://cdn/img.png'], services);
+
+            // getSubmissionByUserAndTask returns null because only rejected/pending
+            // submissions exist (filtered out by status in query)
+            repo.getSubmissionByUserAndTask.mockResolvedValueOnce(null);
+
+            const confirmInteraction: any = {
+                customId: `review-confirm|approve|bronze|${submission.id}`,
+                user: { id: 'admin-1' },
+                client,
+                deferUpdate: vi.fn().mockResolvedValue(undefined),
+                editReply: vi.fn().mockResolvedValue(undefined),
+                channel: adminChannel,
+            };
+
+            await handleAdminButton(confirmInteraction, services);
+
+            // No prior tier — first-time approval, increment only
+            expect(userRepo.incrementStat).toHaveBeenCalledWith('user-1', 'tasksCompletedBronze', 1);
+            expect(userRepo.updateTierStat).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('Confirmation prompt dismissal (regression)', () => {
+        it('updates the confirmation prompt in-place instead of creating a new ephemeral reply', async () => {
+            const { service, repo, services } = createTaskServiceHarness();
+            const { client, adminChannel } = createAdminClientMock();
+
+            const submission = await service.createSubmission('user-1', 'event-1');
+            const stored = { ...submission, screenshotUrls: ['https://cdn/img.png'] };
+            repo.getSubmissionById.mockResolvedValue(stored);
+
+            await service.completeSubmission(client as any, submission.id, ['https://cdn/img.png'], services);
+
+            const confirmInteraction: any = {
+                customId: `review-confirm|approve|bronze|${submission.id}`,
+                user: { id: 'admin-1' },
+                client,
+                deferUpdate: vi.fn().mockResolvedValue(undefined),
+                deferReply: vi.fn().mockResolvedValue(undefined),
+                editReply: vi.fn().mockResolvedValue(undefined),
+                channel: adminChannel,
+            };
+
+            await handleAdminButton(confirmInteraction, services);
+
+            // Must update existing message, not create a new ephemeral reply
+            expect(confirmInteraction.deferUpdate).toHaveBeenCalledTimes(1);
+            expect(confirmInteraction.deferReply).not.toHaveBeenCalled();
+
+            // Must clear components so buttons can't be clicked again
+            expect(confirmInteraction.editReply).toHaveBeenCalledWith(
+                expect.objectContaining({ components: [] })
+            );
         });
     });
 


### PR DESCRIPTION
## Summary
- Fix confirmation prompt not dismissing after approving a submission. Replaced `deferReply` with `deferUpdate` + immediate `editReply` to clear buttons instantly.
- Fix tier stats inflating on upgrades (e.g., bronze to silver incremented silver without decrementing bronze). Added `updateTierStat` method for atomic decrement+increment in a single Firestore write.
- Fix `getSubmissionByUserAndTask` returning rejected submissions as the "highest tier". Filtered query to only return bronze/silver/gold statuses.
- Fix pre-existing type errors in `MovieScheduler.test.ts` and `TaskStreaks.test.ts`.
- Add regression and tier stat tests (18 to 27 test cases).

## Required: Firestore Index Update
The `taskSubmissions` composite index must be updated to include the `status` field. (see #18 )

Closes #18 