### PR TITLE
fix(tasks): accept approval confirmation before submission lookup

### DIFF
--- a/src/modules/tasks/TaskInteractions.ts
+++ b/src/modules/tasks/TaskInteractions.ts
@@ -198,7 +198,6 @@ export async function handleAdminButton(interaction: ButtonInteraction, services
             return;
         }
 
-        // Check current submission status to prevent race condition on concurrent approvals
         const taskRepo = services.repos.taskRepo;
         if (!taskRepo) {
             await interaction.update({
@@ -208,9 +207,15 @@ export async function handleAdminButton(interaction: ButtonInteraction, services
             return;
         }
 
+        await interaction.deferUpdate();
+        await interaction.editReply({
+            content: `⏳ Processing approval...`,
+            components: [],
+        });
+
         const currentSubmission = await taskRepo.getSubmissionById(submissionId);
         if (!currentSubmission) {
-            await interaction.update({
+            await interaction.editReply({
                 content: 'Submission not found.',
                 components: [],
             });
@@ -223,18 +228,12 @@ export async function handleAdminButton(interaction: ButtonInteraction, services
         const requestedTierLevel = tierOrder[tier];
 
         if (currentTierLevel >= requestedTierLevel) {
-            await interaction.update({
+            await interaction.editReply({
                 content: `⚠️ This submission is already approved at ${currentSubmission.status === 'pending' ? 'pending' : currentSubmission.status} tier or higher. Another admin may have processed this.`,
                 components: [],
             });
             return;
         }
-
-        await interaction.deferUpdate();
-        await interaction.editReply({
-            content: `⏳ Processing approval...`,
-            components: [],
-        });
 
         const reviewerId = interaction.user.id;
 

--- a/src/modules/tasks/__tests__/TaskSubmissionFlow.test.ts
+++ b/src/modules/tasks/__tests__/TaskSubmissionFlow.test.ts
@@ -174,6 +174,33 @@ describe('Task submission lifecycle', () => {
             expect(client.channels.fetch).toHaveBeenCalledWith('task-verification-channel-id');
         });
 
+        it('defers approval confirmation before loading submission state', async () => {
+            const callOrder: string[] = [];
+            const { service, repo, services } = createTaskServiceHarness();
+            const { client, adminChannel } = createAdminClientMock();
+
+            const submission = await service.createSubmission('user-1', 'event-1');
+            repo.getSubmissionById.mockImplementation(async () => {
+                callOrder.push('getSubmissionById');
+                return { ...submission, screenshotUrls: ['https://cdn/img.png'] };
+            });
+
+            const confirmInteraction: any = {
+                customId: `review-confirm|approve|bronze|${submission.id}`,
+                user: { id: 'admin-1' },
+                client,
+                deferUpdate: vi.fn().mockImplementation(async () => {
+                    callOrder.push('deferUpdate');
+                }),
+                editReply: vi.fn().mockResolvedValue(undefined),
+                channel: adminChannel,
+            };
+
+            await handleAdminButton(confirmInteraction, services);
+
+            expect(callOrder.slice(0, 2)).toEqual(['deferUpdate', 'getSubmissionById']);
+        });
+
         it('continues approval flow when archiving fails due to permissions', async () => {
             const { service, repo, services } = createTaskServiceHarness();
             const { client, adminChannel } = createAdminClientMock();
@@ -277,7 +304,7 @@ describe('Task submission lifecycle', () => {
             await handleAdminButton(admin2Confirm, services);
 
             // Admin-2 should be rejected with a helpful message
-            expect(admin2Confirm.update).toHaveBeenCalledWith(
+            expect(admin2Confirm.editReply).toHaveBeenCalledWith(
                 expect.objectContaining({
                     content: expect.stringContaining('already approved at bronze tier or higher'),
                     components: [],
@@ -354,15 +381,14 @@ describe('Task submission lifecycle', () => {
             await handleAdminButton(admin1Confirm, services);
 
             // Should reject downgrade
-            expect(admin1Confirm.update).toHaveBeenCalledWith(
+            expect(admin1Confirm.editReply).toHaveBeenCalledWith(
                 expect.objectContaining({
                     content: expect.stringContaining('already approved at gold tier or higher'),
                     components: [],
                 })
             );
 
-            // Should not defer or update status
-            expect(admin1Confirm.deferUpdate).not.toHaveBeenCalled();
+            expect(admin1Confirm.deferUpdate).toHaveBeenCalled();
             expect(repo.updateSubmissionStatus).not.toHaveBeenCalled();
         });
     });


### PR DESCRIPTION
## Summary

Fixes task approval confirmation interactions timing out when submission lookup is slow.

## Details

The approval confirmation button was checking submission state before acknowledging the Discord interaction. If that lookup took too long, Discord could show “Interaction failed” even though the bot might continue processing afterward.

This changes the confirmation flow to defer the button interaction first, then load the submission and continue with the existing approval checks.